### PR TITLE
Revert to the go version 1.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Coimbra1984/gortsplib
 
-go 1.15
+go 1.14
 
 require (
 	github.com/asticode/go-astits v1.10.0


### PR DESCRIPTION
This is needed for the build system in use